### PR TITLE
add tar for rhel family distros

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -13,5 +13,6 @@ pkgs += %w(unzip rsync make gcc) unless platform_family?('mac_os_x', 'windows')
 pkgs += %w(autogen) unless platform_family?('rhel', 'fedora', 'mac_os_x', 'suse', 'windows')
 pkgs += %w(gtar) if platform?('freebsd')
 pkgs += %w(xz-lzma-compat) if platform?('centos')
+pkgs += %w(tar) if platform_family == 'rhel'
 
 default['ark']['package_dependencies'] = pkgs


### PR DESCRIPTION
Cloud images of centos/rhel might not have tar package by default.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/burtlo/ark/64)
<!-- Reviewable:end -->
