### PR TITLE
prevent tmp directory leak

### DIFF
--- a/libraries/unzip_command_builder.rb
+++ b/libraries/unzip_command_builder.rb
@@ -36,7 +36,7 @@ module Ark
       strip_dir = '*/' * resource.strip_components
       cmd = "unzip -q -u -o #{resource.release_file} -d #{tmpdir}"
       cmd += " && rsync -a #{tmpdir}/#{strip_dir} #{resource.path}"
-      cmd += " && rm -rf #{tmpdir}"
+      cmd += " ; rm -rf #{tmpdir}"
       cmd
     end
 


### PR DESCRIPTION
If anything would happen with rsync command, cookbook would not fail, so temporary directories would leak. 

In case of continuous deployment, this cause a problem. For example, running chef-client every 15 mins for 10 archive files could reach 32k limit (in case of ext3) in a month.

Meanwhile, for debug purposes, everybody could easily comment "rm -rf" line, upload cookbook and check what is going wrong.