### PR TITLE
Fixed ark_tar attribute for windows platform

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,7 +3,7 @@ default['ark']['prefix_root'] = '/usr/local'
 default['ark']['prefix_bin'] = '/usr/local/bin'
 default['ark']['prefix_home'] = '/usr/local'
 if node['platform_family'] == 'windows'
-  default['ark']['tar'] = "\"#{default['7-zip']['home']}\\7z.exe\""
+  default['ark']['tar'] = "\"#{node['7-zip']['home']}\\7z.exe\""
 else
   default['ark']['tar'] = '/bin/tar'
 end


### PR DESCRIPTION
default['ark']['tar'] was not set correctly on windows platform, fixed typo