### PR TITLE
Add SmartOS Compatibility

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -4,6 +4,8 @@ default['ark']['prefix_bin'] = '/usr/local/bin'
 default['ark']['prefix_home'] = '/usr/local'
 if node['platform_family'] == 'windows'
   default['ark']['tar'] = "\"#{default['7-zip']['home']}\\7z.exe\""
+elsif node['platform_family'] == 'smartos'
+  default['ark']['tar'] = '/bin/gtar'
 else
   default['ark']['tar'] = '/bin/tar'
 end
@@ -11,7 +13,7 @@ end
 pkgs = %w(libtool autoconf) unless platform_family?('mac_os_x', 'windows')
 pkgs += %w(unzip rsync make gcc) unless platform_family?('mac_os_x', 'windows')
 pkgs += %w(autogen) unless platform_family?('rhel', 'fedora', 'mac_os_x', 'suse', 'windows')
-pkgs += %w(gtar) if platform?('freebsd')
+pkgs += %w(gtar) if (platform?('freebsd') || platform?('smartos'))
 pkgs += %w(xz-lzma-compat) if platform?('centos')
 
 default['ark']['package_dependencies'] = pkgs


### PR DESCRIPTION
Solaris `tar` does not support `--strip-components`, thus leaving an empty directory at the end of an install. We need gtar to gain this support, and make sure to use the respective binary when unpacking. 