### PR TITLE
Added support for RHEL 7 

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -37,7 +37,15 @@ pkgs += %w(unzip rsync gcc) unless platform_family?('mac_os_x', 'windows')
 pkgs += %w(autogen) unless platform_family?('rhel', 'fedora', 'mac_os_x', 'suse', 'windows')
 pkgs += %w(gtar) if platform?('freebsd') || platform?('smartos')
 pkgs += %w(gmake) if platform?('freebsd')
-pkgs += %w(xz-lzma-compat bzip2 tar) if platform_family?('rhel', 'fedora')
+if platform_family?('rhel')
+  if node['platform_version'] >= '7'
+    pkgs += %w(xz bzip2 tar)
+  elsif node['platform_version'] < '7'
+    pkgs += %w(xz-lzma-compat bzip2 tar)
+  end
+elsif platform_family?('fedora')
+  pkgs += %w(xz-lzma-compat bzip2 tar)
+end
 pkgs += %w(shtool pkg-config) if platform_family?('debian')
 
 default['ark']['package_dependencies'] = pkgs

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'frank@chef.io'
 license          'Apache 2.0'
 description      'Provides a custom resource for installing runtime artifacts in a predictable fashion'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.0.1'
+version          '1.0.2'
 
 recipe 'ark::default', 'Installs packages needed by the custom resource'
 


### PR DESCRIPTION
RHEL 7 xm binary includes the xm-lzma-compat. Added support for differentiating RHEL 7, RHEL <= 6 and Fedora